### PR TITLE
Add supabase config fields and worker constants

### DIFF
--- a/app/smartphone/build.gradle.kts
+++ b/app/smartphone/build.gradle.kts
@@ -19,6 +19,8 @@ android {
         versionName = "1.15.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "SUPABASE_URL", "\"<public-url>\"")
+        buildConfigField("String", "SUPABASE_ANON_KEY", "\"<anon-key>\"")
     }
     buildTypes {
         release {

--- a/app/smartphone/src/main/java/com/m3u/smartphone/support/SupportRequestWorker.kt
+++ b/app/smartphone/src/main/java/com/m3u/smartphone/support/SupportRequestWorker.kt
@@ -1,0 +1,27 @@
+package com.m3u.smartphone.support
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.m3u.smartphone.BuildConfig
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class SupportRequestWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val url = BuildConfig.SUPABASE_URL
+        val anonKey = BuildConfig.SUPABASE_ANON_KEY
+        // TODO: Implement request using the constants above
+        return Result.success()
+    }
+
+    companion object {
+        const val TAG = "support_request"
+    }
+}

--- a/app/tv/build.gradle.kts
+++ b/app/tv/build.gradle.kts
@@ -18,6 +18,8 @@ android {
         versionName = "1.0.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "SUPABASE_URL", "\"<public-url>\"")
+        buildConfigField("String", "SUPABASE_ANON_KEY", "\"<anon-key>\"")
     }
     buildTypes {
         release {

--- a/app/tv/src/main/java/com/m3u/tv/support/SupportRequestWorker.kt
+++ b/app/tv/src/main/java/com/m3u/tv/support/SupportRequestWorker.kt
@@ -1,0 +1,27 @@
+package com.m3u.tv.support
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.m3u.tv.BuildConfig
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class SupportRequestWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted params: WorkerParameters
+) : CoroutineWorker(context, params) {
+
+    override suspend fun doWork(): Result {
+        val url = BuildConfig.SUPABASE_URL
+        val anonKey = BuildConfig.SUPABASE_ANON_KEY
+        // TODO: Implement request using the constants above
+        return Result.success()
+    }
+
+    companion object {
+        const val TAG = "support_request"
+    }
+}


### PR DESCRIPTION
## Summary
- define SUPABASE_URL and SUPABASE_ANON_KEY buildConfig fields for smartphone and TV apps
- implement `SupportRequestWorker` in both apps referencing the constants

## Testing
- `./gradlew test` *(fails: No route to host)*