### PR TITLE
Add device ID preference

### DIFF
--- a/app/smartphone/src/main/java/com/m3u/smartphone/ui/business/setting/fragments/preferences/OtherPreferences.kt
+++ b/app/smartphone/src/main/java/com/m3u/smartphone/ui/business/setting/fragments/preferences/OtherPreferences.kt
@@ -16,6 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import com.m3u.core.architecture.preferences.PreferencesKeys
+import com.m3u.core.architecture.preferences.preferenceOf
 import com.m3u.core.unit.DataUnit
 import com.m3u.core.util.basic.title
 import com.m3u.i18n.R.string
@@ -32,6 +34,7 @@ internal fun OtherPreferences(
     val spacing = LocalSpacing.current
     val context = LocalContext.current
     val uriHandler = LocalUriHandler.current
+    val deviceId by preferenceOf(PreferencesKeys.DEVICE_ID)
     Column(
         verticalArrangement = Arrangement.spacedBy(spacing.small),
         modifier = modifier
@@ -47,6 +50,11 @@ internal fun OtherPreferences(
                     }
                 context.startActivity(intent)
             }
+        )
+        Preference(
+            title = stringResource(string.feat_setting_device_id).title(),
+            content = deviceId,
+            icon = Icons.Rounded.PermDeviceInformation
         )
         Preference(
             title = stringResource(string.feat_setting_app_version).title(),

--- a/i18n/src/main/res/values-de-rDE/feat_setting.xml
+++ b/i18n/src/main/res/values-de-rDE/feat_setting.xml
@@ -127,4 +127,5 @@
     <string name="feat_setting_epg_added">Anschließend kannst Du die Playlist mit dem EPG verknüpfen</string>
 
     <string name="feat_setting_randomly_in_favourite">Zufällige Wiedergabe von Favoriten</string>
+    <string name="feat_setting_device_id">Geräte-ID</string>
 </resources>

--- a/i18n/src/main/res/values-es-rES/feat_setting.xml
+++ b/i18n/src/main/res/values-es-rES/feat_setting.xml
@@ -122,4 +122,5 @@
     <string name="feat_setting_epg_added">puede asociar la lista con su(s) EPG</string>
 
     <string name="feat_setting_randomly_in_favourite">reproducir aleatoriamente sólo desde favoritos</string>
+    <string name="feat_setting_device_id">ID del dispositivo</string>
 </resources>

--- a/i18n/src/main/res/values-es-rMX/feat_setting.xml
+++ b/i18n/src/main/res/values-es-rMX/feat_setting.xml
@@ -122,4 +122,5 @@
     <string name="feat_setting_epg_added">puedes vincular la playlist con su(s) EPG</string>
 
     <string name="feat_setting_randomly_in_favourite">reproducir al azar sólo desde favoritos</string>
+    <string name="feat_setting_device_id">ID del dispositivo</string>
 </resources>

--- a/i18n/src/main/res/values-pt-rBR/feat_setting.xml
+++ b/i18n/src/main/res/values-pt-rBR/feat_setting.xml
@@ -120,4 +120,5 @@
     <string name="feat_setting_error_empty_epg">O link do EPG está vazio</string>
     <string name="feat_setting_placeholder_epg">Link do EPG</string>
     <string name="feat_setting_epg_added">Você pode associar uma playlist ao EPG</string>
+    <string name="feat_setting_device_id">ID do dispositivo</string>
 </resources>

--- a/i18n/src/main/res/values-ro-rRO/feat_setting.xml
+++ b/i18n/src/main/res/values-ro-rRO/feat_setting.xml
@@ -84,4 +84,5 @@
     <string name="feat_setting_restoring">restaurare toate listele si canalele</string>
 
     <string name="feat_setting_follow_system_theme">la fel ca tema telefonului</string>
+    <string name="feat_setting_device_id">ID dispozitiv</string>
 </resources>

--- a/i18n/src/main/res/values-zh-rCN/feat_setting.xml
+++ b/i18n/src/main/res/values-zh-rCN/feat_setting.xml
@@ -126,4 +126,5 @@
     <string name="feat_setting_error_empty_epg">EPG链接为空</string>
 
     <string name="feat_setting_randomly_in_favourite">随机播放只播放已收藏的频道</string>
+    <string name="feat_setting_device_id">设备 ID</string>
 </resources>

--- a/i18n/src/main/res/values/feat_setting.xml
+++ b/i18n/src/main/res/values/feat_setting.xml
@@ -130,4 +130,5 @@
     <string name="feat_setting_epg_added">you can then associate the playlist with the EPG</string>
 
     <string name="feat_setting_randomly_in_favourite">play randomly only from favourite</string>
+    <string name="feat_setting_device_id">Device ID</string>
 </resources>


### PR DESCRIPTION
## Summary
- translate a new `feat_setting_device_id` string for all languages
- show a Device ID preference in smartphone settings

## Testing
- `./gradlew lint` *(fails: No route to host)*