### PR TITLE
Fix device ID preference definition

### DIFF
--- a/core/src/main/java/com/m3u/core/architecture/preferences/Preferences.kt
+++ b/core/src/main/java/com/m3u/core/architecture/preferences/Preferences.kt
@@ -32,7 +32,6 @@ import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
-import java.util.UUID
 
 typealias Settings = DataStore<Preferences>
 
@@ -100,7 +99,6 @@ suspend operator fun <T> Settings.set(key: Preferences.Key<T>, value: T) {
 }
 
 private val PREFERENCES: Map<Preferences.Key<*>, *> = listOf(
-    PreferencesKeys.DEVICE_ID to "",
     PreferencesKeys.PLAYLIST_STRATEGY to PlaylistStrategy.ALL,
     PreferencesKeys.ROW_COUNT to 1,
     PreferencesKeys.DEVICE_ID to UUID.randomUUID().toString(),
@@ -151,7 +149,6 @@ suspend fun Settings.applyDefaultValues() {
 private val applied = AtomicBoolean(false)
 
 object PreferencesKeys {
-    val DEVICE_ID = stringPreferencesKey("device_id")
     val PLAYLIST_STRATEGY = intPreferencesKey("playlist-strategy")
     val ROW_COUNT = intPreferencesKey("rowCount")
 


### PR DESCRIPTION
## Summary
- tidy Preferences imports
- remove duplicated preference lines
- ensure DEVICE_ID default is set

## Testing
- `./gradlew test` *(fails: No route to host)*